### PR TITLE
Use middleware to add "DiagnosticSeverity" to diagnostics

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
 import {
-  // Diagnostic,
+  Diagnostic,
+  DiagnosticSeverity,
   ExtensionContext,
-  // HandleDiagnosticsSignature,
+  HandleDiagnosticsSignature,
   LanguageClient,
   LanguageClientOptions,
   ServerOptions,
@@ -57,7 +58,7 @@ export async function activate(context: ExtensionContext) {
     documentSelector: [{ language: 'jade' }],
     initializationOptions,
     middleware: {
-      // handleDiagnostics,
+      handleDiagnostics,
     },
   };
 
@@ -70,16 +71,15 @@ export function deactivate(): Thenable<any> | undefined {
   return client?.stop();
 }
 
-// MEMO: If necessary, diagnostics can be adjusted.
-//async function handleDiagnostics(uri: string, diagnostics: Diagnostic[], next: HandleDiagnosticsSignature) {
-//  next(
-//    uri,
-//    diagnostics.map((d) => {
-//      // MEMO: If necessary, diagnostics can be adjusted.
-//      return d;
-//    })
-//  );
-//}
+async function handleDiagnostics(uri: string, diagnostics: Diagnostic[], next: HandleDiagnosticsSignature) {
+  next(
+    uri,
+    diagnostics.map((d) => {
+      d.severity = DiagnosticSeverity.Error;
+      return d;
+    })
+  );
+}
 
 function getConfigDevServerPath() {
   return workspace.getConfiguration('pug').get<string>('dev.serverPath', '');


### PR DESCRIPTION
It appears that the diagnostics in pug-language-server do not have DiagnosticSeverity set. In coc.nvim, if DiagnosticSeverity is not set in the diagnostics, Signs will not be displayed.

First, add DiagnosticSeverity in the client-side middleware. 

This issue has also been reported to the upstream. https://github.com/volarjs/pug-language-tools/issues/3